### PR TITLE
Requirements.txt - use compatible items rather than absolutes.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-opencv-python==4.8.0.74
-mediapipe==0.10.0
-gTTS==2.3.2
+opencv-python~=4.8.0.74
+mediapipe~=0.10.0
+gTTS~=2.3.2
 # Update


### PR DESCRIPTION
I wasn't able to set this up on my machine with the default absolute versions.